### PR TITLE
Honor music delay of 0

### DIFF
--- a/src/main/java/com/gizmo/music/mixin/MusicMixin.java
+++ b/src/main/java/com/gizmo/music/mixin/MusicMixin.java
@@ -12,14 +12,14 @@ public class MusicMixin {
 
 	@Inject(method = "getMinDelay", at = @At("RETURN"), cancellable = true)
 	public void musicManager$setConfigBasedMinDelay(CallbackInfoReturnable<Integer> ci) {
-		if (MusicManager.minSongDelay > -1) {
+		if (MusicManager.minSongDelay > -1 && ci.getReturnValueI() > 0) {
 			ci.setReturnValue(Math.round((Math.min(MusicManager.minSongDelay, MusicManager.maxSongDelay) + 1) * 20.0F));
 		}
 	}
 
 	@Inject(method = "getMaxDelay", at = @At("RETURN"), cancellable = true)
 	public void musicManager$setConfigBasedMaxDelay(CallbackInfoReturnable<Integer> ci) {
-		if (MusicManager.maxSongDelay > -1) {
+		if (MusicManager.maxSongDelay > -1 && ci.getReturnValueI() > 0) {
 			ci.setReturnValue(Math.round((Math.max(MusicManager.minSongDelay, MusicManager.maxSongDelay) + 1) * 20.0F));
 		}
 	}


### PR DESCRIPTION
Hey Gizmo. Hope you're doing well.

Here's a quick little thing for music manager. Musics that intentionally have delays set to 0 (like The End or Dragon boss music) are set that way so they can play immediately when necessary. It probably isn't a good idea to hook into the music objects in this case, so this PR simply checks if the return value is already 0 before going through with modifying it in `MusicMixin`.